### PR TITLE
Add blog post on programming theory building

### DIFF
--- a/contents/programming-as-theory-building.md
+++ b/contents/programming-as-theory-building.md
@@ -1,0 +1,74 @@
+---
+title: Programming as Theory Building—Why RTFM Isn't Enough
+slug: programming-as-theory-building
+date: 6/17/2024
+description: "Docs are great, but without a shared team theory you're lost. This first post in a three-part series breaks down why RTFM alone won't get you there."
+photo: "./blogContent/programming-theory/theory-thumbnail.jpg"
+banner: "../blogContent/programming-theory/theory-banner.jpg"
+---
+
+## Let's be real for a second
+
+Every time you hop onto a new project someone will tell you to RTFM—"Read The Manual"—and maybe toss you a link to the docs. After that, you're on your own. If that actually worked, onboarding would be painless. Instead, you read the docs, trace through code, and still feel like you're missing half the puzzle. Sound familiar?
+
+In 1985, Peter Naur wrote **Programming as Theory Building** and basically said the real program isn't the code or the docs. It's the shared mental model the team builds together. Until you have that theory in your head, the diagrams and architecture docs won't save you. This post kicks off a three-part series where we'll look at why "just read the docs" (or RTFM) isn't enough and how to bridge that gap.
+
+---
+
+## The "Theory" Behind the Code
+
+Here's the gist:
+
+- **The code isn't the program.** It's a partial record of what the team actually knows.
+- **The theory is alive.** It spreads through conversations, pairing sessions, design docs, whiteboard chats, and yes, sometimes a good old walkthrough.
+- **You can't transfer theory with a doc link.** Even the best wiki won't capture the full reasoning and trade-offs behind the code.
+
+Once you start thinking about code as a living theory, the common pain points make a lot more sense.
+
+---
+
+## Where Theory Building Explains Everything
+
+- **Onboarding that never clicks.** You throw the new engineer an onboarding guide and a shiny diagram. They still struggle. It's because the team theory didn't get transferred.
+- **Missing decision context.** Ever wonder why a strange business rule exists? The docs might give a hint, but the real backstory is trapped in conversations long forgotten.
+- **Docs vs. reality.** Diagrams look neat, but when you step through the running code, half the modules are missing or things take a weird path no one documented.
+- **Confusing code reviews.** Someone suggests a refactor and the response is basically "trust me." The knowledge lives in heads, not in docs.
+- **Knowledge silos.** That one dev is the only person who understands a module. When they're on PTO, everyone else is stuck.
+
+If you've bumped into any of these, you've seen theory building—or the lack of it—in action.
+
+---
+
+## What This Means for Teams
+
+Documentation is helpful, and I write plenty of it, but it's always incomplete. Think of docs as a map. The map is useful, but it's not the territory. To really navigate the system you need the living theory that exists in the team.
+
+That's why pairing, code reviews, and working through real tickets are so valuable. They build and share that theory much faster than a doc ever could.
+
+---
+
+## How Do We Build and Share Theory?
+
+- **Make knowledge sharing a habit.** Encourage questions, pair often, and keep the history alive through conversations.
+- **Treat living knowledge as an asset.** When you spot a gap, start a discussion. A doc update helps, but a quick chat often does more.
+- **Onboard by experience.** Give new teammates real tasks. Let them ask "why" at every step, not just "what." That's how the theory sticks.
+
+---
+
+## What's Next in This Series
+
+This is the first of three posts on building and sharing understanding:
+
+1. **Programming as Theory Building (you're here!).** Why RTFM won't give you the full picture.
+2. **The Map Is Not the Territory.** Docs and diagrams are approximations. Relying on them alone is a trap.
+3. **Bridging the Gap—Practical Steps.** Concrete ways to use things like C4 diagrams and pairing to turn docs into living knowledge.
+
+If "just read the docs" has ever left you frustrated, stick around. We'll dive into how to make onboarding and cross-team understanding far smoother.
+
+---
+
+Programming is theory building. The true value is in the team's shared understanding. Your job isn't just to write code—it's to build and evolve that theory together. Stay tuned for the next post where we'll dig into why the map is never the territory, and what to do about it.
+
+---
+
+Have your own war stories or tips on transferring knowledge? Drop them in the comments or hit me up. Always happy to compare notes.


### PR DESCRIPTION
## Summary
- add new blog post `programming-as-theory-building.md`
- discuss why RTFM isn't enough when onboarding
- outline upcoming posts in a new three-part series

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6874fc47cff8832eb23734e5dc320291